### PR TITLE
GSMP Protocol을 따르는 wrapper 기능 구현 #65

### DIFF
--- a/src/includes/global.h
+++ b/src/includes/global.h
@@ -37,6 +37,12 @@
 /* Ȱ���� ���� ���� extern */
 extern int gRecvFlag;
 extern uint32_t gFailCount[4];
+
+// tGsmpMsg gSendMsg;
+extern tGsmpMsg gAcbSendMsg;
+extern tGsmpMsg gAcbEchoSendMsg;
+extern tGsmpMsg gTelemetryMsg;
+
 extern tImuData gImuData;
 extern tSeekerData gSeekerData;
 extern tDVector3 gAccCmd;
@@ -114,6 +120,13 @@ enum eStatus
 	INTERNAL_ERROR = 2,
 };
 
+enum eModeStatus
+{
+	WAIT = 0,
+	ENGAGE = 1,
+	SAFE = 2,
+	REEXPLORE = 3,
+};
 
 /*=====CBIT&PBIT ���� �� �µ�  üũ  ����=====*/
 extern double gVoltageInt;

--- a/src/includes/gsmpWrapper.h
+++ b/src/includes/gsmpWrapper.h
@@ -7,8 +7,8 @@
 #include "global.h"
 
 /*
- * void* gsmpWrapper(int messageId, int messageStatus, void* pPayload, int destId)
+ * void* gsmpWrapper(int messageId, int messageStatus, void* pPayload)
  * GSMP(GoSim Message Protocol)의 전송을 지원한다.
  * return : ByteStream 반환
  **/
-tGsmpMsg gsmpWrapper(int messageId, int messageStatus, void* pPayload, int destId);
+void gsmpWrapper(int messageId, int messageStatus, void* pPayload);

--- a/src/includes/tasks/uartSendTaskMain.h
+++ b/src/includes/tasks/uartSendTaskMain.h
@@ -6,12 +6,12 @@
 // This typedef contains configuration information for the device.
 void runUartSend();
 void explode();		// TODO : 삭제
-void sendData(uint8_t* buffer, uint16_t len);
+void sendUartData(tGsmpMsg* msg);
 void uartSendTaskMain(void *pvParameters);
 
 static const uint8_t headerSize = sizeof(tGsmpMessageHeader);
-static const uint8_t cmdSize = sizeof(gControlCmd);
+static const uint8_t cmdSize = sizeof(tAcbPayload);
 static const uint8_t crcSize = 2;
-static const uint8_t bufferSizeNoCRC = sizeof(tGsmpMessageHeader) + sizeof(gControlCmd);
+static const uint8_t bufferSizeNoCRC = sizeof(tGsmpMessageHeader) + sizeof(tAcbPayload);
 
 #endif

--- a/src/utils/global.c
+++ b/src/utils/global.c
@@ -45,7 +45,11 @@ XSysMon_Config *gXadcConfig;
 
 uint32_t gFailCount[4];
 
-tGSsmpMsg gSendMsg;
+// tGsmpMsg gSendMsg;
+tGsmpMsg gAcbSendMsg;
+tGsmpMsg gAcbEchoSendMsg;
+tGsmpMsg gTelemetryMsg;
+
 
 /**
  * gImuData

--- a/src/utils/gsmpWrapper.c
+++ b/src/utils/gsmpWrapper.c
@@ -1,46 +1,54 @@
 #include "gsmpWrapper.h"
-
+#define xil_printf(...)  do {} while(0)
 /*
  * tGsmpMsg* gsmpWrapper(int messageId, int messageStatus, void* pPayload, int destId)
  * GSMP(GoSim Message Protocol)의 전송을 지원한다.
- * return : gsmpMsg 반환
+ * return : X
  *
  **/
-void gsmpWrapper(int messageId, int messageStatus, void* pPayload, int destId)
+void gsmpWrapper(int messageId, int messageStatus, void* pPayload)
 {
 
 	uint8_t headerSize = sizeof(tGsmpMessageHeader);
 	uint8_t payloadSize;
 	uint8_t crcSize = 2;
-
+	tGsmpMsg* pDestMsg = NULL;
+	uint8_t destId;
 	/**
 	 * [데이터의 포맷을 wrap한다.]
 	 * 송수신하는 모든 시스템은 리틀 엔디안 형식을 사용한다고 가정한다.
 	 * 1. 인자값을 바탕으로 바이트 스트림을 생성한다.
 	 * 2. 생성한 바이트스트림을 반환한다.
 	 */
-	tGsmpMsg msg;
 	// 헤더 설정
-	msg.header.startflag = START_FLAG;
-	msg.header.msgId = messageId;
+	//msg.header.startflag = START_FLAG;
+	//msg.header.msgId = messageId;
+
 	switch(messageId)
 	{
 	case ACB_SEND_MSG_ID :
 	{
-		msg.header.destId = ACB_ID;
+		destId = ACB_ID;
 		payloadSize = sizeof(tAcbPayload);
+		//gAcbSendMsg
+		pDestMsg = &gAcbSendMsg;
+		xil_printf("ACB_SEND_MSG\r\n");
 		break;
 	}
 	case ACB_ECHO_SEND_MSG_ID :
 	{
-		msg.header.destId = ACB_ID;
+		destId = ACB_ID;
 		payloadSize = sizeof(uint8_t);
+		//gAcbEchoSendMsg
+		pDestMsg = &gAcbEchoSendMsg;
 		break;
 	}
 	case TELEMETRY_MSG_ID :
 	{
-		msg.header.destId = TELMETRY_ID;
+		destId = TELMETRY_ID;
 		payloadSize = sizeof(tTelemetryData);
+		//gTelemetryMsg
+		pDestMsg = &gTelemetryMsg;
 		break;
 	}
 	case IMU_MSG_ID :
@@ -56,25 +64,30 @@ void gsmpWrapper(int messageId, int messageStatus, void* pPayload, int destId)
 		break;
 	}
 	}
+	// payload 저장
+	if (pDestMsg != NULL && pPayload != NULL)
+	{
+		// header 저장
+		pDestMsg->header.startflag = START_FLAG;
+		pDestMsg->header.srcId = GCU_ID;
+		pDestMsg->header.destId = destId;
+		pDestMsg->header.msgId = messageId;
+		pDestMsg->header.msgStat = messageStatus;
+		pDestMsg->header.msgLen = payloadSize;
 
-	uint8_t bufferSizeNoCRC = sizeof(tGsmpMessageHeader) + payloadSize;
+		memcpy(pDestMsg->payload, pPayload, payloadSize);
+		xil_printf("WRAPPER : payloadSize = %d bytes\r\n", payloadSize);
 
-	msg.header.srcId = GCU_ID;
-	msg.header.destId = ACB_ID;
-	msg.header.msgStat = messageStatus;
-	msg.header.msgLen = payloadSize;
-	// pPayload와 메세지 형식 내 지정된 사이즈 동일한지 검사
-	msg.payload = &pPayload;
+		// CRC를 계산하여 tGsmpMsg에 저장
+		// CRC 계산용 임시 버퍼를 지정하여 crc 연산을 수행한다.
+		uint8_t tmpBuf[headerSize+payloadSize];
+		//헤더 복사
+		memcpy(tmpBuf, (const uint8_t*)&pDestMsg->header, headerSize);
+		// payload 내용 복사 (payload가 가리키는 메모리 내용)
+		memcpy(tmpBuf + headerSize, (const uint8_t*)pDestMsg->payload, payloadSize);
+		// CRC 계산
+		pDestMsg->CRC = calcCrc(tmpBuf, headerSize + payloadSize);
+	}
 
-	// CRC를 계산하여 tGsmpMsg에 저장한다.
-	// CRC 계산용 임시 버퍼를 지정하여 crc 연산을 수행한다.
-	uint8_t tempBuf[bufferSizeNoCRC];
-	memcpy(tempBuf, (const uint8_t*) &msg.header, headerSize);
-	memcpy(tempBuf + headerSize, (const uint8_t*) msg.payload, sizeof(pPayload));
-	uint16_t crc = calcCrc(tempBuf, sizeof(tempBuf));
-
-	msg.CRC = crc;
-	memcpy(msg, gSendMsg, sizeof(gSendMsg));
 	return;
-
 }


### PR DESCRIPTION
## 📌 PR 개요
* 전송에 필요한 모든 Send Message 전역 변수 선언 - global.c 참고
* tAcbPayload 전송까지 구현 (예제 코드 존재) - uartSendTaskMain.c 참고
* CRC 계산을 위한 tmpBuf는 불가피하게 선언하였음 - gsmpWrapper.c 참고
* print blocking으로 인한 UART 수신 불가 이슈를 막기 위해 무효화하였음

## 🔍 변경 사항
- [ ] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩토링
- [ ] 문서 수정

