### PR TITLE
fix: Cbit Task 이더넷 체크 기능 수정

### DIFF
--- a/src/includes/global.h
+++ b/src/includes/global.h
@@ -13,6 +13,7 @@
 #include "xil_io.h"
 #include "gsgTypes.h"
 #include "xemacps_hw.h"
+#include "xemacps.h"
 
 /* ��ũ�� ���� */
 #ifndef TRUE
@@ -55,6 +56,8 @@ extern XUartPs gUartPs;
 extern XUartPs_Config *gUartConfig;
 extern XSysMon gSysMonInst;
 extern XSysMon_Config *gXadcConfig;
+extern XEmacPs gXemacPsInst;
+extern XEmacPs_Config *gXemacConfig;
 
 /**
  * [task handlers]

--- a/src/tasks/initTask/initTaskMain.c
+++ b/src/tasks/initTask/initTaskMain.c
@@ -86,6 +86,9 @@ void initMemoryCheck(){
 static void tcpipInitDone(void *arg) {
     ip4_addr_t ipaddr, netmask, gw, serverIp;
 
+    gXemacConfig = XEmacPs_LookupConfig( XPAR_PS7_ETHERNET_0_DEVICE_ID );
+    XEmacPs_CfgInitialize( &gXemacPsInst, gXemacConfig, gXemacConfig->BaseAddress);
+
     unsigned char macAddr[] = { 0x00, 0x18, 0x3E, 0x04, 0x50, 0x84 };
     err_t err;
 
@@ -96,7 +99,7 @@ static void tcpipInitDone(void *arg) {
     IP4_ADDR(&gw, 192, 168, 1, 1);
     ipaddr_aton(SERVER_IP_ADDR, &serverIp);
 
-    // TODO: tcp_init()�쓽 �슦�꽑 �닚�쐞媛� �궙�븘�꽌, init�씠 �뒪耳�以꾨쭅 以묎컙�뿉 �셿猷뚮릺�뒗 �쁽�긽�씠 �깮湲대떎.
+    // TODO: tcp_init() 쓽  슦 꽑  닚 쐞媛   궙 븘 꽌, init 씠  뒪耳 以꾨쭅 以묎컙 뿉  셿猷뚮릺 뒗  쁽 긽 씠  깮湲대떎.
 
     if (!xemac_add(&gGsgNetif, &ipaddr, &netmask, &gw, macAddr,
     		PLATFORM_EMAC_BASEADDR))
@@ -117,9 +120,9 @@ static void tcpipInitDone(void *arg) {
                    xemacif_input_thread,
                    &gGsgNetif,
                    1024,
-                   4);
+                   29);
 
-    // UDP �겢�씪�씠�뼵�듃 �꽕�젙
+    // UDP  겢 씪 씠 뼵 듃  꽕 젙
     gpUdpClientConn = netconn_new(NETCONN_UDP);
     if (gpUdpClientConn == NULL) {
         xil_printf("netconn_new failed!\r\n");
@@ -136,7 +139,7 @@ static void tcpipInitDone(void *arg) {
 	}
 	xil_printf("client setting complete %d\r\n", err);
 
-	// UDP �꽌踰� �꽕�젙
+	// UDP  꽌踰   꽕 젙
     gpUdpServerConn = netconn_new(NETCONN_UDP);
     if (gpUdpServerConn == NULL) {
         xil_printf("netconn_new failed!\r\n");
@@ -160,7 +163,6 @@ static void tcpipInitDone(void *arg) {
 
 void initUdpServer() {
     xil_printf("-----lwIP netconn UDP Test Application------\r\n");
-
     tcpip_init(tcpipInitDone, NULL);
 }
 

--- a/src/utils/global.c
+++ b/src/utils/global.c
@@ -42,6 +42,8 @@ XUartPs gUartPs;
 XUartPs_Config *gUartConfig;
 XSysMon gSysMonInst;
 XSysMon_Config *gXadcConfig;
+XEmacPs gXemacPsInst;
+XEmacPs_Config *gXemacConfig;
 
 uint32_t gFailCount[4];
 


### PR DESCRIPTION
## 📌 PR 개요
이더넷 체크 기능이 현재 이더넷 상태와 무관하게 Failed를 표시하는 오류 수정

이더넷 상태를 읽어오는 api 사용
api 의 인자로 현재 이더넷 설정값을 담는 XemacConfig가 필요하기에 init에 코드 추가

gXemacConfig, gXemacPsInst를 global에 추가