### PR TITLE
refactor: wrapper.c 전송 데이터 저장 위치를 전역 버퍼에 저장하도록 수정 #71

### DIFF
--- a/src/includes/global.h
+++ b/src/includes/global.h
@@ -34,14 +34,25 @@
 #define UART_BAUD 115200
 #endif
 
+#ifndef TELEMETRY_MSG_SIZE
+#define TELEMETRY_MSG_SIZE 165
+#endif
+#ifndef ACB_SEND_MSG_SIZE
+#define ACB_SEND_MSG_SIZE 37
+#endif
+#ifndef ACB_ECHO_SEND_MSG_SIZE
+#define ACB_ECHO_SEND_MSG_SIZE 17
+#endif
 /* Ȱ���� ���� ���� extern */
 extern int gRecvFlag;
 extern uint32_t gFailCount[4];
 
 // tGsmpMsg gSendMsg;
-extern tGsmpMsg gAcbSendMsg;
-extern tGsmpMsg gAcbEchoSendMsg;
-extern tGsmpMsg gTelemetryMsg;
+//extern tGsmpMsg gAcbSendMsg;
+//extern tGsmpMsg gAcbEchoSendMsg;
+//extern tGsmpMsg gTelemetryMsg;
+extern uint8_t gSendBuffer[TELEMETRY_MSG_SIZE];
+
 
 extern tImuData gImuData;
 extern tSeekerData gSeekerData;

--- a/src/includes/tasks/uartSendTaskMain.h
+++ b/src/includes/tasks/uartSendTaskMain.h
@@ -6,7 +6,7 @@
 // This typedef contains configuration information for the device.
 void runUartSend();
 void explode();		// TODO : 삭제
-void sendUartData(tGsmpMsg* msg);
+void sendUartData();
 void uartSendTaskMain(void *pvParameters);
 
 static const uint8_t headerSize = sizeof(tGsmpMessageHeader);

--- a/src/tasks/uartSendTask/uartSendTaskMain.c
+++ b/src/tasks/uartSendTask/uartSendTaskMain.c
@@ -35,9 +35,9 @@ void runUartSend()
 	}
 	gRecvFlag = FALSE;
 
-	gControlCmd.x = 1.02;
-	gControlCmd.y = 3.04;
-	gControlCmd.z = 5.06;
+	gControlCmd.x = 1.42;
+	gControlCmd.y = 3.14;
+	gControlCmd.z = 2.38;
 
 	// example tAcbPayload
 	tAcbPayload examplePayload;
@@ -48,34 +48,12 @@ void runUartSend()
 	gsmpWrapper(ACB_SEND_MSG_ID, OK, &examplePayload);
 
 	// 전송을 수행한다.
-	sendUartData(&gAcbSendMsg);
+	sendUartData();
 }
 
 
-void sendUartData(tGsmpMsg* msg)
+void sendUartData()
 {
-    const uint8_t headerSize = sizeof(tGsmpMessageHeader);
-    const uint8_t payloadSize = msg->header.msgLen;
-    const uint8_t crcSize = sizeof(uint16_t);
-    const uint8_t totalLen = headerSize + payloadSize + crcSize;
-
-    uint8_t txBuffer[totalLen];
-
-    // 1. 헤더 복사
-    memcpy(txBuffer, &msg->header, headerSize);
-    // 2. payload 복사
-    memcpy(txBuffer + headerSize, (const uint8_t*) msg->payload, payloadSize);
-    // 3. CRC 복사 (Little Endian)
-    txBuffer[headerSize + payloadSize + 0] = msg->CRC & 0xFF;
-    txBuffer[headerSize + payloadSize + 1] = (msg->CRC >> 8) & 0xFF;
-
-    // 4. 디버깅용 출력
-        xil_printf("UART TX (%d bytes): ", totalLen);
-        for (int i = 0; i < totalLen; ++i) {
-            xil_printf("%02X ", txBuffer[i]);
-        }
-        xil_printf("\r\n");
-
     // 5. 전송
-    XUartPs_Send(&gUartPs, txBuffer, totalLen);
+    XUartPs_Send(&gUartPs, gSendBuffer, ACB_SEND_MSG_SIZE);
 }

--- a/src/utils/global.c
+++ b/src/utils/global.c
@@ -46,9 +46,10 @@ XSysMon_Config *gXadcConfig;
 uint32_t gFailCount[4];
 
 // tGsmpMsg gSendMsg;
-tGsmpMsg gAcbSendMsg;
-tGsmpMsg gAcbEchoSendMsg;
-tGsmpMsg gTelemetryMsg;
+//tGsmpMsg gAcbSendMsg;
+//tGsmpMsg gAcbEchoSendMsg;
+//tGsmpMsg gTelemetryMsg;
+uint8_t gSendBuffer[TELEMETRY_MSG_SIZE];
 
 
 /**

--- a/src/utils/gsmpWrapper.c
+++ b/src/utils/gsmpWrapper.c
@@ -1,54 +1,41 @@
 #include "gsmpWrapper.h"
 #define xil_printf(...)  do {} while(0)
 /*
- * tGsmpMsg* gsmpWrapper(int messageId, int messageStatus, void* pPayload, int destId)
- * GSMP(GoSim Message Protocol)의 전송을 지원한다.
- * return : X
+ * tGsmpMsg* gsmpWrapper(int messageId, int messageStatus, void* pPayload)
+ * GSMP(GoSim Message Protocol)의 전송을 지원한다. 데이터 스트림을 gSendData에 저장한다.
+ * return : -
  *
  **/
 void gsmpWrapper(int messageId, int messageStatus, void* pPayload)
 {
 
-	uint8_t headerSize = sizeof(tGsmpMessageHeader);
+	const uint8_t headerSize = sizeof(tGsmpMessageHeader);
 	uint8_t payloadSize;
-	uint8_t crcSize = 2;
-	tGsmpMsg* pDestMsg = NULL;
+	tGsmpMessageHeader header;
 	uint8_t destId;
 	/**
 	 * [데이터의 포맷을 wrap한다.]
 	 * 송수신하는 모든 시스템은 리틀 엔디안 형식을 사용한다고 가정한다.
-	 * 1. 인자값을 바탕으로 바이트 스트림을 생성한다.
-	 * 2. 생성한 바이트스트림을 반환한다.
+	 * 1. 인자값을 바탕으로 바이트 스트림을 생성하여 저장한다.
 	 */
-	// 헤더 설정
-	//msg.header.startflag = START_FLAG;
-	//msg.header.msgId = messageId;
-
 	switch(messageId)
 	{
 	case ACB_SEND_MSG_ID :
 	{
 		destId = ACB_ID;
 		payloadSize = sizeof(tAcbPayload);
-		//gAcbSendMsg
-		pDestMsg = &gAcbSendMsg;
-		xil_printf("ACB_SEND_MSG\r\n");
 		break;
 	}
 	case ACB_ECHO_SEND_MSG_ID :
 	{
 		destId = ACB_ID;
 		payloadSize = sizeof(uint8_t);
-		//gAcbEchoSendMsg
-		pDestMsg = &gAcbEchoSendMsg;
 		break;
 	}
 	case TELEMETRY_MSG_ID :
 	{
 		destId = TELMETRY_ID;
 		payloadSize = sizeof(tTelemetryData);
-		//gTelemetryMsg
-		pDestMsg = &gTelemetryMsg;
 		break;
 	}
 	case IMU_MSG_ID :
@@ -64,29 +51,29 @@ void gsmpWrapper(int messageId, int messageStatus, void* pPayload)
 		break;
 	}
 	}
-	// payload 저장
-	if (pDestMsg != NULL && pPayload != NULL)
+	if (pPayload != NULL)
 	{
-		// header 저장
-		pDestMsg->header.startflag = START_FLAG;
-		pDestMsg->header.srcId = GCU_ID;
-		pDestMsg->header.destId = destId;
-		pDestMsg->header.msgId = messageId;
-		pDestMsg->header.msgStat = messageStatus;
-		pDestMsg->header.msgLen = payloadSize;
+		// header 매핑
+		header.startflag = START_FLAG;
+		header.srcId = GCU_ID;
+		header.destId = destId;
+		header.msgId = messageId;
+		header.msgStat = messageStatus;
+		header.msgLen = payloadSize;
 
-		memcpy(pDestMsg->payload, pPayload, payloadSize);
-		xil_printf("WRAPPER : payloadSize = %d bytes\r\n", payloadSize);
+		// gSendBuffer 구성
+	    // 1. 헤더 복사
+	    memcpy(gSendBuffer, &header, headerSize);
+	    // 2. payload 복사
+	    memcpy(gSendBuffer + headerSize, (const uint8_t*) pPayload, payloadSize);
 
-		// CRC를 계산하여 tGsmpMsg에 저장
-		// CRC 계산용 임시 버퍼를 지정하여 crc 연산을 수행한다.
-		uint8_t tmpBuf[headerSize+payloadSize];
-		//헤더 복사
-		memcpy(tmpBuf, (const uint8_t*)&pDestMsg->header, headerSize);
-		// payload 내용 복사 (payload가 가리키는 메모리 내용)
-		memcpy(tmpBuf + headerSize, (const uint8_t*)pDestMsg->payload, payloadSize);
 		// CRC 계산
-		pDestMsg->CRC = calcCrc(tmpBuf, headerSize + payloadSize);
+		uint16_t crc = calcCrc(gSendBuffer, headerSize + payloadSize);
+
+	    // 3. CRC 복사 (Little Endian)
+	    gSendBuffer[headerSize + payloadSize + 0] = crc & 0xFF;
+	    gSendBuffer[headerSize + payloadSize + 1] = (crc >> 8) & 0xFF;
+
 	}
 
 	return;


### PR DESCRIPTION
## 📌 PR 개요
gSendBuffer로 데이터 전송 타입을 수정하였습니다.

## 🔍 변경 사항
- [ ] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩토링
- [ ] 문서 수정
