### PR TITLE
refactor: task chain을 두 개로 나누어 전체 주기 20ms로 감축

### DIFF
--- a/src/tasks/cbitTask/cbitTaskMain.c
+++ b/src/tasks/cbitTask/cbitTaskMain.c
@@ -182,5 +182,6 @@ void cbitTaskMain( void *pvParameters )
 
       xil_printf("RUN -- %s\r\n", pcTaskGetName(NULL));
       runCbit();
+      xTaskNotifyGive(xTelemetryTaskHandle);
     }
 }

--- a/src/tasks/guidanceTask/guidanceTaskMain.c
+++ b/src/tasks/guidanceTask/guidanceTaskMain.c
@@ -60,5 +60,6 @@ void guidanceTaskMain(void *pvParameters)
 
         xil_printf("RUN -- %s\r\n", pcTaskGetName(NULL));
         guidanceRun();
+        xTaskNotifyGive(xControlTaskHandle);
     }
 }

--- a/src/tasks/navigationTask/navigationTaskMain.c
+++ b/src/tasks/navigationTask/navigationTaskMain.c
@@ -71,5 +71,6 @@ void navigationTaskMain( void *pvParameters )
 
         xil_printf("RUN -- %s\r\n", pcTaskGetName(NULL));
         navigationRun();
+        xTaskNotifyGive(xGuidanceTaskHandle);
     }
 }

--- a/src/tasks/schedulingTask/schedulingTaskMain.c
+++ b/src/tasks/schedulingTask/schedulingTaskMain.c
@@ -28,33 +28,9 @@ void schedulingTaskMain(void *pvParameters)
     	xTaskNotifyGive(xUdpReceiveTaskHandle);
     	vTaskDelayUntil(&last, pdMS_TO_TICKS(UDP_RECEIVE_DEADLINE));
 
-    	xil_printf("WAKE - Nav\r\n", pcTaskGetName(NULL));
-    	xTaskNotifyGive(xNavigationTaskHandle);
-    	vTaskDelayUntil(&last, pdMS_TO_TICKS(NAVIGATION_DEADLINE));
-
-    	xil_printf("WAKE - gui\r\n", pcTaskGetName(NULL));
-		xTaskNotifyGive(xGuidanceTaskHandle);
-		vTaskDelayUntil(&last, pdMS_TO_TICKS(GUIDANCE_DEADLINE));
-
-    	xil_printf("WAKE - cont\r\n", pcTaskGetName(NULL));
-		xTaskNotifyGive(xControlTaskHandle);
-		vTaskDelayUntil(&last, pdMS_TO_TICKS(CONTOL_DEADLINE));
-
     	xil_printf("WAKE - uart send\r\n", pcTaskGetName(NULL));
 		xTaskNotifyGive(xUartSendTaskHandle);
 		vTaskDelayUntil(&last, pdMS_TO_TICKS(UART_SEND_DEADLINE));
-
-    	xil_printf("WAKE - uart recv\r\n", pcTaskGetName(NULL));
-		xTaskNotifyGive(xUartReceiveTaskHandle);
-		vTaskDelayUntil(&last, pdMS_TO_TICKS(UART_RECV_DEADLINE));
-
-    	xil_printf("WAKE - cbit\r\n", pcTaskGetName(NULL));
-		xTaskNotifyGive(xCbitTaskHandle);
-		vTaskDelayUntil(&last, pdMS_TO_TICKS(CBIT_DEADLINE));
-
-    	xil_printf("WAKE - tele\r\n", pcTaskGetName(NULL));
-		xTaskNotifyGive(xTelemetryTaskHandle);
-		vTaskDelayUntil(&last, pdMS_TO_TICKS(TELEMETRY_DEADLINE));
     }
 }
 

--- a/src/tasks/uartReceiveTask/uartReceiveTaskMain.c
+++ b/src/tasks/uartReceiveTask/uartReceiveTaskMain.c
@@ -19,5 +19,6 @@ void uartReceiveTaskMain()
 
         xil_printf("RUN -- %s\r\n", pcTaskGetName(NULL));
         runUartReceive();
+        xTaskNotifyGive(xCbitTaskHandle);
     }
 }

--- a/src/tasks/uartSendTask/uartSendTaskMain.c
+++ b/src/tasks/uartSendTask/uartSendTaskMain.c
@@ -6,5 +6,6 @@ void uartSendTaskMain(void *pvParameters) {
         ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
         xil_printf("RUN -- %s\r\n", pcTaskGetName(NULL));
         runUartSend();
+        xTaskNotifyGive(xCbitTaskHandle);
 	}
 }

--- a/src/tasks/udpReceiveTask/udpReceiveTaskMain.c
+++ b/src/tasks/udpReceiveTask/udpReceiveTaskMain.c
@@ -148,6 +148,7 @@ void udpReceiveTaskMain( void *pvParameters )
 
         xil_printf("RUN -- %s\r\n", pcTaskGetName(NULL));
         udpReceiveRun();
+        xTaskNotifyGive(xNavigationTaskHandle);
     }
 
 }


### PR DESCRIPTION
## 📌 PR 개요
task chain을 두 개로 나누어 전체 주기 20ms로 줄였습니다.
Missile Simulator의 IMU, Seeker 모델이 20ms 주기로 전송하는 버전을 사용해주세요.

## 🔍 변경 사항
- [ ] 버그 수정
- [ ] 기능 추가
- [x] 코드 리팩토링
- [ ] 문서 수정

## 📎관련 이슈
- #82 

